### PR TITLE
Replace macro with behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,78 +19,73 @@ end
 **Wallet utilities**
 
 ```elixir
-secret = "my secret"
+iex> secret = "my secret"
 
 # For Lisk
-lisk_wallet = Dpos.Wallet.generate_lisk(secret)
+iex> lisk_wallet = Dpos.Wallet.generate_lisk(secret)
 
 # For Shift
-shift_wallet = Dpos.Wallet.generate_shift(secret)
+iex> shift_wallet = Dpos.Wallet.generate_shift(secret)
 
 # For any lisk-like wallet
-wallet = Dpos.Wallet.generate(secret, "XYZ")
-
-# Output
+iex> wallet = Dpos.Wallet.generate(secret, "XYZ")
 %Dpos.Wallet{
   address: "2340651171948227443XYZ",
   priv_key: <<185, 209, 208, 19, 246, 0, 236, 27, 241, 107, 174, 106, 54, 52,
     202, 209, 93, 204, 73, 12, 159, 40, 53, 118, 66, 1, 164, 26, 29, 112, 222,
-    68, 249, 101, 174, 176, 6, 137, 118, 4, 103, 241, 92, 60, 161, 68, 190, 100,
-    ...>>,
+    68>>,
   pub_key: <<249, 101, 174, 176, 6, 137, 118, 4, 103, 241, 92, 60, 161, 68, 190,
     100, 196, 154, 35, 122, 177, 234, 113, 116, 109, 35, 81, 173, 215, 138, 11,
     101>>
 }
 
 # Sign a message
-{:ok, signature} = Dpos.Wallet.sign_message(wallet, "I Love LWF")
+iex> {:ok, signature} = Dpos.Wallet.sign_message(wallet, "My Signed Message")
 
 # Verify a message
-:ok = Dpos.Wallet.verify_message(wallet, "I Love LWF", signature)
+iex> :ok = Dpos.Wallet.verify_message(wallet, "My Signed Message", signature)
 ```
 
 **Transaction utilities**
 
 ```elixir
-tx =
-  %{amount: 10_000_000_000, fee: 10_000_000, recipientId: "9961568538380190560LWF"}
-  |> Dpos.Tx.Send.build()
-  |> Dpos.Tx.Send.sign(wallet)
-
-# The transaction can be normalized to be easier to read
-tx |> Dpos.Tx.Send.normalize() |> IO.inspect()
-
-# Output
-%Dpos.Tx{
-  type: 0,
-  id: "4370528448668269583",
-  recipientId: "9961568538380190560LWF",
-  senderPublicKey: "f965aeb00689760467f15c3ca144be64c49a237ab1ea71746d2351add78a0b65",
-  signature: "d35ea618fc55a8d6ad1f63e76bfb241387e11487f7999cfcb263e051b5dd846682ad48e8d1d255c345a88684eeb8c4ac559febc62b93d9d0ff724f3547ba4503",
-  signSignature: nil,
-  amount: 10000000000,
-  fee: 10000000,
-  timestamp: 89501419,
-  address_suffix_length: 3,
-  asset: nil
-}
+iex> tx = \
+iex>  %{amount: 10_000_000_000, fee: 10_000_000, recipientId: "2340651171948227443XYZ"} \
+iex>  |> Dpos.Tx.Send.build() \
+iex>  |> Dpos.Tx.Send.sign(wallet)
 
 # Optional: signing the tx using a second private key
-Dpos.Tx.Send.sign(tx, wallet, second_priv_key)
+iex> Dpos.Tx.Send.sign(tx, wallet, second_priv_key)
 
 # It is possible to pass a secret/suffix tuple as second argument to Tx.sign/3:
-Dpos.Tx.Send.sign(tx, {"my secret", "L"})
+iex> Dpos.Tx.Send.sign(tx, {"my secret", "L"})
 
 # Finally we can broadcast our transaction to a remote node (or a local node)
-network = [
-  nethash: "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511",
-  version: "1.5.0",
-  uri: "http://127.0.0.1:8000"
-]
+iex> network = [
+iex>   nethash: "ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511",
+iex>   version: "1.5.0",
+iex>   uri: "http://127.0.0.1:8000"
+iex> ]
 
-tx
-|> Dpos.Tx.Send.normalize()
-|> Dpos.Net.broadcast(network)
+iex> tx
+iex> |> Dpos.Tx.Send.normalize()
+iex> |> Dpos.Net.broadcast(network)
+
+# The transaction can be normalized to be easier to read and to be broadcasted to a remote node
+iex> Dpos.Tx.Send.normalize(tx)
+%Dpos.Tx{
+  id: "14577272354830356516",
+  recipientId: "2340651171948227443XYZ",
+  senderPublicKey: "f965aeb00689760467f15c3ca144be64c49a237ab1ea71746d2351add78a0b65",
+  signature: "271d56c46e49d9b01707ba7ec90ea69a59a9e6f606abf532315e5e2fa327b465e9d9f4ef6c37d11ca84aec61f8b138881b9afa92ba39123dc6622057ea53f50f",
+  signSignature: nil,
+  timestamp: 252848803,
+  type: 0,
+  address_suffix_length: 3,
+  amount: 10000000000,
+  asset: %{},
+  fee: 10000000
+}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ iex> :ok = Dpos.Wallet.verify_message(wallet, "My Signed Message", signature)
 
 ```elixir
 iex> tx = \
-iex>  %{amount: 10_000_000_000, fee: 10_000_000, recipientId: "2340651171948227443XYZ"} \
+iex>  %{amount: 10_000_000_000, fee: 10_000_000, recipient: "2340651171948227443XYZ"} \
 iex>  |> Dpos.Tx.Send.build() \
 iex>  |> Dpos.Tx.Send.sign(wallet)
 
@@ -68,11 +68,11 @@ iex>   uri: "http://127.0.0.1:8000"
 iex> ]
 
 iex> tx
-iex> |> Dpos.Tx.Send.normalize()
+iex> |> Dpos.Tx.normalize()
 iex> |> Dpos.Net.broadcast(network)
 
 # The transaction can be normalized to be easier to read and to be broadcasted to a remote node
-iex> Dpos.Tx.Send.normalize(tx)
+iex> Dpos.Tx.normalize(tx)
 %Dpos.Tx{
   id: "14577272354830356516",
   recipientId: "2340651171948227443XYZ",

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ end
 iex> secret = "my secret"
 
 # For Lisk
-iex> lisk_wallet = Dpos.Wallet.generate_lisk(secret)
+iex> lisk_wallet = Wallet.generate_lisk(secret)
 
 # For Shift
-iex> shift_wallet = Dpos.Wallet.generate_shift(secret)
+iex> shift_wallet = Wallet.generate_shift(secret)
 
 # For any lisk-like wallet
-iex> wallet = Dpos.Wallet.generate(secret, "XYZ")
-%Dpos.Wallet{
+iex> wallet = Wallet.generate(secret, "XYZ")
+%Wallet{
   address: "2340651171948227443XYZ",
   priv_key: <<185, 209, 208, 19, 246, 0, 236, 27, 241, 107, 174, 106, 54, 52,
     202, 209, 93, 204, 73, 12, 159, 40, 53, 118, 66, 1, 164, 26, 29, 112, 222,
@@ -40,25 +40,25 @@ iex> wallet = Dpos.Wallet.generate(secret, "XYZ")
 }
 
 # Sign a message
-iex> {:ok, signature} = Dpos.Wallet.sign_message(wallet, "My Signed Message")
+iex> {:ok, signature} = Wallet.sign_message(wallet, "My Signed Message")
 
 # Verify a message
-iex> :ok = Dpos.Wallet.verify_message(wallet, "My Signed Message", signature)
+iex> :ok = Wallet.verify_message(wallet, "My Signed Message", signature)
 ```
 
 **Transaction utilities**
 
 ```elixir
 iex> tx = \
-iex>  %{amount: 10_000_000_000, fee: 10_000_000, recipient: "2340651171948227443XYZ"} \
-iex>  |> Dpos.Tx.Send.build() \
-iex>  |> Dpos.Tx.Send.sign(wallet)
+iex>  Tx.Send
+iex>  |> Tx.build(%{amount: 10_000_000_000, fee: 10_000_000, recipient: "2340651171948227443XYZ"}) \
+iex>  |> Tx.sign(wallet)
 
 # Optional: signing the tx using a second private key
-iex> Dpos.Tx.Send.sign(tx, wallet, second_priv_key)
+iex> Tx.sign(tx, wallet, second_priv_key)
 
 # It is possible to pass a secret/suffix tuple as second argument to Tx.sign/3:
-iex> Dpos.Tx.Send.sign(tx, {"my secret", "L"})
+iex> Tx.sign(tx, {"my secret", "L"})
 
 # Finally we can broadcast our transaction to a remote node (or a local node)
 iex> network = [
@@ -68,12 +68,12 @@ iex>   uri: "http://127.0.0.1:8000"
 iex> ]
 
 iex> tx
-iex> |> Dpos.Tx.normalize()
-iex> |> Dpos.Net.broadcast(network)
+iex> |> Tx.normalize()
+iex> |> Net.broadcast(network)
 
 # The transaction can be normalized to be easier to read and to be broadcasted to a remote node
-iex> Dpos.Tx.normalize(tx)
-%Dpos.Tx{
+iex> Tx.normalize(tx)
+%Tx{
   id: "14577272354830356516",
   recipientId: "2340651171948227443XYZ",
   senderPublicKey: "f965aeb00689760467f15c3ca144be64c49a237ab1ea71746d2351add78a0b65",

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ iex> :ok = Wallet.verify_message(wallet, "My Signed Message", signature)
 **Transaction utilities**
 
 ```elixir
-iex> tx = \
-iex>  Tx.Send
+iex> tx =
+iex>  Tx.Send \
 iex>  |> Tx.build(%{amount: 10_000_000_000, fee: 10_000_000, recipient: "2340651171948227443XYZ"}) \
 iex>  |> Tx.sign(wallet)
 
@@ -67,8 +67,8 @@ iex>   version: "1.5.0",
 iex>   uri: "http://127.0.0.1:8000"
 iex> ]
 
-iex> tx
-iex> |> Tx.normalize()
+iex> tx \
+iex> |> Tx.normalize() \
 iex> |> Net.broadcast(network)
 
 # The transaction can be normalized to be easier to read and to be broadcasted to a remote node

--- a/README.md
+++ b/README.md
@@ -88,6 +88,37 @@ iex> Tx.normalize(tx)
 }
 ```
 
+## Custom Transactions
+
+You can implement the `Dpos.Tx` behaviour in order to create your own transaction types.
+
+The behaviour requires you to implement 2 functions, `type_id/0` and `get_child_bytes/1`.
+
+Example:
+
+```elixir
+defmodule MyApp.Transaction do
+  @behaviour Dpos.Tx
+
+  @impl Dpos.Tx
+  def type_id do
+    # The integer value that will be used in the `type` field.
+    3333
+  end
+
+  @impl Dpos.Tx
+  def get_child_bytes(%Tx{}) do
+    # This function must return a binary.
+    #
+    # If your transaction uses custom fields you'd need to implement a logic to compute these fields,
+    # otherwise return an empty binary.
+    #
+    # See `Dpos.Tx.Vote` for your reference.
+  end
+end
+
+```
+
 ## Contributing
 
 Clone the repository and run `$ mix test` to make sure everything is working.

--- a/lib/net.ex
+++ b/lib/net.ex
@@ -13,7 +13,7 @@ defmodule Dpos.Net do
   The transaction must be already normalized.
   """
   @type network() :: [uri: String.t(), nethash: String.t(), version: String.t()]
-  @spec broadcast(%Dpos.Tx{}, network()) :: {:ok, String.t()} | {:error, term}
+  @spec broadcast(%Dpos.Tx.Normalized{}, network()) :: {:ok, String.t()} | {:error, term}
   def broadcast(tx, net) when is_list(net) do
     with :ok <- validate_network(net),
          {:ok, resp} <- request(net, %{transaction: tx}),

--- a/lib/tx/delegate.ex
+++ b/lib/tx/delegate.ex
@@ -1,18 +1,24 @@
 defmodule Dpos.Tx.Delegate do
-  use Dpos.Tx, type: 2
+  alias Dpos.Tx
+
+  @behaviour Tx
+
+  @impl Tx
+  def type_id, do: 2
+
+  @impl Tx
+  def get_child_bytes(%{asset: %{delegate: %{username: username}}}) when is_binary(username),
+    do: username
+
+  def get_child_bytes(_tx),
+    do: raise("Please set a delegate name\nSee Tx.Delegate.set_delegate/2")
 
   @doc """
   Sets the delegate username to be registered.
   """
-  @spec set_delegate(%Dpos.Tx{}, String.t()) :: %Dpos.Tx{}
-  def set_delegate(%Dpos.Tx{} = tx, username) when is_binary(username) do
+  @spec set_delegate(%Tx{}, String.t()) :: %Tx{}
+  def set_delegate(%Tx{} = tx, username) when is_binary(username) do
     username = username |> String.downcase() |> String.trim()
     Map.put(tx, :asset, %{delegate: %{username: username}})
   end
-
-  defp get_child_bytes(%{asset: %{delegate: %{username: username}}}) when is_binary(username),
-    do: username
-
-  defp get_child_bytes(_),
-    do: raise("Please set a delegate name\nSee Tx.Delegate.set_delegate/2")
 end

--- a/lib/tx/multi_sig.ex
+++ b/lib/tx/multi_sig.ex
@@ -1,13 +1,36 @@
 defmodule Dpos.Tx.MultiSig do
-  use Dpos.Tx, type: 4
+  alias Dpos.Tx
+
+  @behaviour Tx
+
+  @impl Tx
+  def type_id, do: 4
+
+  @impl Tx
+  def get_child_bytes(%{asset: %{multisignature: %{min: m, keysgroup: k, lifetime: t}}})
+      when is_integer(m) and is_integer(t) and is_list(k) do
+    keys = Enum.join(k)
+    <<m::size(8), t::size(8), keys::bytes>>
+  end
+
+  def get_child_bytes(_tx) do
+    [
+      "Invalid multi signature\n" <>
+        "See Tx.MultiSig.set_lifetime/2\n" <>
+        "See Tx.MultiSig.set_min/2\n" <>
+        "See Tx.MultiSig.add_public_key/2"
+    ]
+    |> Enum.join()
+    |> raise()
+  end
 
   @doc """
   Sets the lifetime in seconds of the multisignature.
 
   The lifetime must be >= 3600 and <= 259200.
   """
-  @spec set_lifetime(%Dpos.Tx{}, pos_integer) :: %Dpos.Tx{}
-  def set_lifetime(%Dpos.Tx{} = tx, ttl)
+  @spec set_lifetime(%Tx{}, pos_integer) :: %Tx{}
+  def set_lifetime(%Tx{} = tx, ttl)
       when is_integer(ttl) and ttl >= 3600 and ttl <= 259_200 do
     ms =
       tx
@@ -22,8 +45,8 @@ defmodule Dpos.Tx.MultiSig do
 
   The minimum possible value is 2.
   """
-  @spec set_min(%Dpos.Tx{}, pos_integer()) :: %Dpos.Tx{}
-  def set_min(%Dpos.Tx{} = tx, min) when is_integer(min) and min >= 2 do
+  @spec set_min(%Tx{}, pos_integer()) :: %Tx{}
+  def set_min(%Tx{} = tx, min) when is_integer(min) and min >= 2 do
     ms =
       tx
       |> get_multi_signature()
@@ -35,8 +58,8 @@ defmodule Dpos.Tx.MultiSig do
   @doc """
   Adds a public key to the keysgroup field of the multisignature.
   """
-  @spec add_public_key(%Dpos.Tx{}, String.t()) :: %Dpos.Tx{}
-  def add_public_key(%Dpos.Tx{} = tx, pub_key)
+  @spec add_public_key(%Tx{}, String.t()) :: %Tx{}
+  def add_public_key(%Tx{} = tx, pub_key)
       when is_binary(pub_key) and byte_size(pub_key) == 64 do
     ms =
       tx
@@ -44,23 +67,6 @@ defmodule Dpos.Tx.MultiSig do
       |> add_to_keysgroup(pub_key)
 
     Map.put(tx, :asset, %{multisignature: ms})
-  end
-
-  defp get_child_bytes(%{asset: %{multisignature: %{min: m, keysgroup: k, lifetime: t}}})
-       when is_integer(m) and is_integer(t) and is_list(k) do
-    keys = Enum.join(k)
-    <<m::size(8), t::size(8), keys::bytes>>
-  end
-
-  defp get_child_bytes(_) do
-    [
-      "Invalid multi signature\n" <>
-        "See Tx.MultiSig.set_lifetime/2\n" <>
-        "See Tx.MultiSig.set_min/2\n" <>
-        "See Tx.MultiSig.add_public_key/2"
-    ]
-    |> Enum.join()
-    |> raise()
   end
 
   defp get_multi_signature(%{asset: %{multisignature: ms}}) when is_map(ms), do: ms

--- a/lib/tx/normalized.ex
+++ b/lib/tx/normalized.ex
@@ -22,14 +22,15 @@ defmodule Dpos.Tx.Normalized do
   """
   @spec normalize(%Tx{}) :: %Tx.Normalized{}
   def normalize(%Tx{} = tx) do
-    attrs = Map.take(tx, [:id, :type, :timestamp, :amount, :fee, :asset])
+    attrs = Map.take(tx, [:id, :timestamp, :amount, :fee, :asset])
 
     %__MODULE__{}
     |> Map.merge(attrs)
+    |> Map.put(:type, tx.type.type_id())
     |> Map.put(:recipientId, tx.recipient)
     |> Map.put(:senderPublicKey, Utils.hexdigest(tx.public_key))
     |> Map.put(:signature, Utils.hexdigest(tx.signature))
-    |> Map.put(:signSignature, Utils.hexdigest(tx.sign_signature))
+    |> Map.put(:signSignature, Utils.hexdigest(tx.second_signature))
     |> normalize_asset()
   end
 

--- a/lib/tx/normalized.ex
+++ b/lib/tx/normalized.ex
@@ -9,37 +9,26 @@ defmodule Dpos.Tx.Normalized do
     :signSignature,
     :timestamp,
     :type,
-    address_suffix_length: 1,
     amount: 0,
     asset: %{},
     fee: 0
   ]
 
-  @json_keys [
-    :id,
-    :type,
-    :fee,
-    :amount,
-    :recipientId,
-    :senderPublicKey,
-    :signature,
-    :signSignature,
-    :timestamp,
-    :asset
-  ]
-
-  @derive {Jason.Encoder, only: @json_keys}
   defstruct @keys
 
   @doc """
   Normalizes the transaction in a format that it could be broadcasted through a relay node.
   """
-  @spec normalize(%Tx{}) :: %Tx{}
+  @spec normalize(%Tx{}) :: %Tx.Normalized{}
   def normalize(%Tx{} = tx) do
-    tx
-    |> Map.put(:senderPublicKey, Utils.hexdigest(tx.senderPublicKey))
+    attrs = Map.take(tx, [:id, :type, :timestamp, :amount, :fee, :asset])
+
+    %__MODULE__{}
+    |> Map.merge(attrs)
+    |> Map.put(:recipientId, tx.recipient)
+    |> Map.put(:senderPublicKey, Utils.hexdigest(tx.public_key))
     |> Map.put(:signature, Utils.hexdigest(tx.signature))
-    |> Map.put(:signSignature, Utils.hexdigest(tx.signSignature))
+    |> Map.put(:signSignature, Utils.hexdigest(tx.sign_signature))
     |> normalize_asset()
   end
 

--- a/lib/tx/normalized.ex
+++ b/lib/tx/normalized.ex
@@ -14,6 +14,7 @@ defmodule Dpos.Tx.Normalized do
     fee: 0
   ]
 
+  @derive Jason.Encoder
   defstruct @keys
 
   @doc """

--- a/lib/tx/normalized.ex
+++ b/lib/tx/normalized.ex
@@ -1,0 +1,52 @@
+defmodule Dpos.Tx.Normalized do
+  alias Dpos.{Tx, Utils}
+
+  @keys [
+    :id,
+    :recipientId,
+    :senderPublicKey,
+    :signature,
+    :signSignature,
+    :timestamp,
+    :type,
+    address_suffix_length: 1,
+    amount: 0,
+    asset: %{},
+    fee: 0
+  ]
+
+  @json_keys [
+    :id,
+    :type,
+    :fee,
+    :amount,
+    :recipientId,
+    :senderPublicKey,
+    :signature,
+    :signSignature,
+    :timestamp,
+    :asset
+  ]
+
+  @derive {Jason.Encoder, only: @json_keys}
+  defstruct @keys
+
+  @doc """
+  Normalizes the transaction in a format that it could be broadcasted through a relay node.
+  """
+  @spec normalize(%Tx{}) :: %Tx{}
+  def normalize(%Tx{} = tx) do
+    tx
+    |> Map.put(:senderPublicKey, Utils.hexdigest(tx.senderPublicKey))
+    |> Map.put(:signature, Utils.hexdigest(tx.signature))
+    |> Map.put(:signSignature, Utils.hexdigest(tx.signSignature))
+    |> normalize_asset()
+  end
+
+  # Called for Tx.Signature
+  defp normalize_asset(%{type: 1, asset: %{signature: %{publicKey: pk}}} = tx) do
+    Map.put(tx, :asset, %{signature: %{publicKey: Utils.hexdigest(pk)}})
+  end
+
+  defp normalize_asset(tx), do: tx
+end

--- a/lib/tx/normalized.ex
+++ b/lib/tx/normalized.ex
@@ -1,7 +1,8 @@
 defmodule Dpos.Tx.Normalized do
   alias Dpos.{Tx, Utils}
 
-  @keys [
+  @derive Jason.Encoder
+  defstruct [
     :id,
     :recipientId,
     :senderPublicKey,
@@ -13,9 +14,6 @@ defmodule Dpos.Tx.Normalized do
     asset: %{},
     fee: 0
   ]
-
-  @derive Jason.Encoder
-  defstruct @keys
 
   @doc """
   Normalizes the transaction in a format that it could be broadcasted through a relay node.

--- a/lib/tx/send.ex
+++ b/lib/tx/send.ex
@@ -1,3 +1,11 @@
 defmodule Dpos.Tx.Send do
-  use Dpos.Tx, type: 0
+  alias Dpos.Tx
+
+  @behaviour Tx
+
+  @impl Tx
+  def type_id, do: 0
+
+  @impl Tx
+  def get_child_bytes(%Tx{}), do: ""
 end

--- a/lib/tx/signature.ex
+++ b/lib/tx/signature.ex
@@ -1,11 +1,13 @@
 defmodule Dpos.Tx.Signature do
-  use Dpos.Tx, type: 1
+  alias Dpos.Tx
+
+  use Tx, type: 1
 
   @doc """
   Sets the public key to register for second signature.
   """
-  @spec set_public_key(%Dpos.Tx{}, binary()) :: %Dpos.Tx{}
-  def set_public_key(%Dpos.Tx{} = tx, pub_key)
+  @spec set_public_key(%Tx{}, binary()) :: %Tx{}
+  def set_public_key(%Tx{} = tx, pub_key)
       when is_binary(pub_key) and byte_size(pub_key) == 32 do
     Map.put(tx, :asset, %{signature: %{publicKey: pub_key}})
   end
@@ -13,11 +15,7 @@ defmodule Dpos.Tx.Signature do
   defp get_child_bytes(%{asset: %{signature: %{publicKey: pk}}}), do: <<pk::bytes>>
 
   defp get_child_bytes(_) do
-    "Please set the publick key you would like to register\nSee Tx.Signature.set_public_key/2"
+    "Please set the publick key you would like to register.\nSee Tx.Signature.set_public_key/2."
     |> raise()
-  end
-
-  defp normalize_asset(%{asset: %{signature: %{publicKey: pk}}} = tx) do
-    Map.put(tx, :asset, %{signature: %{publicKey: Dpos.Utils.hexdigest(pk)}})
   end
 end

--- a/lib/tx/signature.ex
+++ b/lib/tx/signature.ex
@@ -1,7 +1,18 @@
 defmodule Dpos.Tx.Signature do
   alias Dpos.Tx
 
-  use Tx, type: 1
+  @behaviour Tx
+
+  @impl Tx
+  def type_id, do: 1
+
+  @impl Tx
+  def get_child_bytes(%{asset: %{signature: %{publicKey: pk}}}), do: <<pk::bytes>>
+
+  def get_child_bytes(_) do
+    "Please set the publick key you would like to register.\nSee Tx.Signature.set_public_key/2."
+    |> raise()
+  end
 
   @doc """
   Sets the public key to register for second signature.
@@ -10,12 +21,5 @@ defmodule Dpos.Tx.Signature do
   def set_public_key(%Tx{} = tx, pub_key)
       when is_binary(pub_key) and byte_size(pub_key) == 32 do
     Map.put(tx, :asset, %{signature: %{publicKey: pub_key}})
-  end
-
-  defp get_child_bytes(%{asset: %{signature: %{publicKey: pk}}}), do: <<pk::bytes>>
-
-  defp get_child_bytes(_) do
-    "Please set the publick key you would like to register.\nSee Tx.Signature.set_public_key/2."
-    |> raise()
   end
 end

--- a/lib/tx/tx.ex
+++ b/lib/tx/tx.ex
@@ -5,7 +5,7 @@ defmodule Dpos.Tx do
   @callback type_id() :: integer()
   @callback get_child_bytes(%__MODULE__{}) :: binary()
 
-  @keys [
+  defstruct [
     :id,
     :recipient,
     :public_key,
@@ -18,8 +18,6 @@ defmodule Dpos.Tx do
     amount: 0,
     fee: 0
   ]
-
-  defstruct @keys
 
   @doc """
   Builds a new transaction.

--- a/lib/tx/tx.ex
+++ b/lib/tx/tx.ex
@@ -1,6 +1,4 @@
 defmodule Dpos.Tx do
-  import Dpos.Utils, only: [hexdigest: 1]
-
   alias Dpos.Crypto.Ed25519
 
   @keys [
@@ -17,20 +15,6 @@ defmodule Dpos.Tx do
     fee: 0
   ]
 
-  @json_keys [
-    :id,
-    :type,
-    :fee,
-    :amount,
-    :recipientId,
-    :senderPublicKey,
-    :signature,
-    :signSignature,
-    :timestamp,
-    :asset
-  ]
-
-  @derive {Jason.Encoder, only: @json_keys}
   defstruct @keys
 
   @doc """
@@ -48,6 +32,10 @@ defmodule Dpos.Tx do
     else
       Map.put(attrs, :timestamp, Dpos.Time.now())
     end
+  end
+
+  def normalize(%Dpos.Tx{} = tx) do
+    Dpos.NormalizedTx.normalize(tx)
   end
 
   defmacro __using__(keys) do
@@ -98,18 +86,6 @@ defmodule Dpos.Tx do
         sign(tx, wallet, second_priv_key)
       end
 
-      @doc """
-      Normalizes the transaction in a format that it could be broadcasted through a relay node.
-      """
-      @spec normalize(%Dpos.Tx{}) :: %Dpos.Tx{}
-      def normalize(%Dpos.Tx{} = tx) do
-        tx
-        |> Map.put(:senderPublicKey, hexdigest(tx.senderPublicKey))
-        |> Map.put(:signature, hexdigest(tx.signature))
-        |> Map.put(:signSignature, hexdigest(tx.signSignature))
-        |> normalize_asset()
-      end
-
       defp create_signature(tx, priv_key, field \\ :signature)
 
       defp create_signature(%Dpos.Tx{} = tx, nil, _field), do: tx
@@ -147,9 +123,7 @@ defmodule Dpos.Tx do
 
       defp get_child_bytes(%Dpos.Tx{}), do: ""
 
-      defp normalize_asset(%Dpos.Tx{} = tx), do: tx
-
-      defoverridable get_child_bytes: 1, normalize_asset: 1
+      defoverridable get_child_bytes: 1
     end
   end
 end

--- a/lib/tx/tx.ex
+++ b/lib/tx/tx.ex
@@ -2,12 +2,15 @@ defmodule Dpos.Tx do
   alias Dpos.Crypto.Ed25519
   alias Dpos.{Tx, Utils, Wallet}
 
+  @callback type_id() :: integer()
+  @callback get_child_bytes(%__MODULE__{}) :: binary()
+
   @keys [
     :id,
     :recipient,
     :public_key,
     :signature,
-    :sign_signature,
+    :second_signature,
     :timestamp,
     :type,
     address_suffix_length: 1,
@@ -19,13 +22,95 @@ defmodule Dpos.Tx do
   defstruct @keys
 
   @doc """
-  Validates timestamp value.
+  Builds a new transaction.
+  """
+  @spec build(module(), map()) :: %Tx{}
+  def build(mod, attrs) do
+    attrs =
+      attrs
+      |> Map.put(:type, mod)
+      |> Tx.ensure_timestamp()
+
+    struct!(Tx, attrs)
+  end
+
+  @doc """
+  Signs the transaction with the sender private key.
+
+  It accepts either a `Dpos.Wallet` or a `{"secret", "L"}` tuple as second argument
+  where the first element is the secret and the second element is the address suffix
+  (i.e. `"L"` for Lisk).
+
+  A secondary private_key can also be provided as third argument.
+  """
+  @type wallet_or_secret() :: %Wallet{} | {String.t(), String.t()}
+  @spec sign(%Tx{}, wallet_or_secret(), binary() | nil) :: %Tx{}
+  def sign(tx, wallet_or_secret, second_priv_key \\ nil)
+
+  def sign(%Tx{} = tx, %Wallet{} = wallet, second_priv_key) do
+    tx
+    |> Map.put(:public_key, wallet.pub_key)
+    |> Map.put(:address_suffix_length, wallet.suffix_length)
+    |> attach_signature(wallet.priv_key)
+    |> attach_second_signature(second_priv_key)
+    |> calculate_id()
+  end
+
+  def sign(%Tx{} = tx, {secret, suffix}, second_priv_key)
+      when is_binary(secret) and is_binary(suffix) do
+    wallet = Wallet.generate(secret, suffix)
+    sign(tx, wallet, second_priv_key)
+  end
+
+  defp attach_second_signature(%Tx{} = tx, nil), do: tx
+
+  defp attach_second_signature(%Tx{} = tx, second_priv_key) do
+    Map.put(tx, :second_signature, calculate_signature(tx, second_priv_key))
+  end
+
+  defp attach_signature(%Tx{} = tx, priv_key) do
+    Map.put(tx, :signature, calculate_signature(tx, priv_key))
+  end
+
+  defp calculate_signature(%Tx{} = tx, priv_key) do
+    {:ok, signature} =
+      tx
+      |> compute_hash()
+      |> Ed25519.sign(priv_key)
+
+    signature
+  end
+
+  defp calculate_id(%Tx{} = tx) do
+    <<head::bytes-size(8), _rest::bytes>> = compute_hash(tx)
+    id = head |> Utils.reverse_binary() |> to_string()
+    Map.put(tx, :id, id)
+  end
+
+  defp compute_hash(%Tx{} = tx) do
+    bytes =
+      :erlang.list_to_binary([
+        <<tx.type.type_id()>>,
+        <<tx.timestamp::little-integer-size(32)>>,
+        <<tx.public_key::bytes-size(32)>>,
+        Utils.address_to_binary(tx.recipient, tx.address_suffix_length),
+        <<tx.amount::little-integer-size(64)>>,
+        tx.type.get_child_bytes(tx),
+        Utils.signature_to_binary(tx.signature),
+        Utils.signature_to_binary(tx.second_signature)
+      ])
+
+    :crypto.hash(:sha256, bytes)
+  end
+
+  @doc """
+  Ensure transaction has a correct timestamp value.
 
   Check if timestamp is present and not negative,
   otherwise it will be set to `Dpos.Time.now/0`.
   """
-  @spec validate_timestamp(map()) :: map()
-  def validate_timestamp(attrs) when is_map(attrs) do
+  @spec ensure_timestamp(map()) :: map()
+  def ensure_timestamp(attrs) when is_map(attrs) do
     ts = attrs[:timestamp]
 
     if ts && is_integer(ts) && ts >= 0 do
@@ -37,94 +122,5 @@ defmodule Dpos.Tx do
 
   def normalize(%Tx{} = tx) do
     Tx.Normalized.normalize(tx)
-  end
-
-  defmacro __using__(keys) do
-    unless keys[:type], do: raise("option 'type' is required")
-
-    quote do
-      @type wallet_or_secret() :: %Wallet{} | {String.t(), String.t()}
-
-      @doc """
-      Builds a new transaction.
-      """
-      @spec build(map()) :: %Tx{}
-      def build(attrs) do
-        keys = Enum.into(unquote(keys), %{})
-
-        attrs =
-          attrs
-          |> Map.merge(keys)
-          |> Tx.validate_timestamp()
-
-        struct!(Tx, attrs)
-      end
-
-      @doc """
-      Signs the transaction with the sender private key.
-
-      It accepts either a `Dpos.Wallet` or a `{"secret", "L"}` tuple as second argument
-      where the first element is the secret and the second element is the address suffix
-      (i.e. `"L"` for Lisk).
-
-      A secondary private_key can also be provided as third argument.
-      """
-      @spec sign(%Tx{}, wallet_or_secret, binary()) :: %Tx{}
-      def sign(tx, wallet_or_secret, second_priv_key \\ nil)
-
-      def sign(%Tx{} = tx, %Wallet{} = wallet, second_priv_key) do
-        tx
-        |> Map.put(:public_key, wallet.pub_key)
-        |> Map.put(:address_suffix_length, wallet.suffix_length)
-        |> create_signature(wallet.priv_key)
-        |> create_signature(second_priv_key, :sign_signature)
-        |> determine_id()
-      end
-
-      def sign(%Tx{} = tx, {secret, suffix}, second_priv_key)
-          when is_binary(secret) and is_binary(suffix) do
-        wallet = Wallet.generate(secret, suffix)
-        sign(tx, wallet, second_priv_key)
-      end
-
-      defp create_signature(tx, priv_key, field \\ :signature)
-
-      defp create_signature(%Tx{} = tx, nil, _field), do: tx
-
-      defp create_signature(%Tx{} = tx, priv_key, field) do
-        {:ok, signature} =
-          tx
-          |> compute_hash()
-          |> Ed25519.sign(priv_key)
-
-        Map.put(tx, field, signature)
-      end
-
-      defp determine_id(%Tx{} = tx) do
-        <<head::bytes-size(8), _rest::bytes>> = compute_hash(tx)
-        id = head |> Utils.reverse_binary() |> to_string()
-        Map.put(tx, :id, id)
-      end
-
-      defp compute_hash(%Tx{} = tx) do
-        bytes =
-          :erlang.list_to_binary([
-            <<tx.type>>,
-            <<tx.timestamp::little-integer-size(32)>>,
-            <<tx.public_key::bytes-size(32)>>,
-            Utils.address_to_binary(tx.recipient, tx.address_suffix_length),
-            <<tx.amount::little-integer-size(64)>>,
-            get_child_bytes(tx),
-            Utils.signature_to_binary(tx.signature),
-            Utils.signature_to_binary(tx.sign_signature)
-          ])
-
-        :crypto.hash(:sha256, bytes)
-      end
-
-      defp get_child_bytes(%Tx{}), do: ""
-
-      defoverridable get_child_bytes: 1
-    end
   end
 end

--- a/lib/tx/vote.ex
+++ b/lib/tx/vote.ex
@@ -1,33 +1,39 @@
 defmodule Dpos.Tx.Vote do
-  use Dpos.Tx, type: 3
+  alias Dpos.Tx
+
+  @behaviour Tx
+
+  @impl Tx
+  def type_id, do: 3
+
+  @impl Tx
+  def get_child_bytes(%Tx{asset: %{votes: votes}}) when is_list(votes),
+    do: <<Enum.join(votes)::bytes>>
+
+  def get_child_bytes(_tx) do
+    [
+      "Please vote or unvote at least a public key",
+      "See Tx.Vote.vote/2",
+      "See Tx.Vote.unvote/2"
+    ]
+    |> Enum.join("\n")
+    |> raise()
+  end
 
   @doc """
   Adds the delegate's public key to vote.
   """
-  @spec vote(%Dpos.Tx{}, String.t()) :: %Dpos.Tx{}
-  def vote(%Dpos.Tx{} = tx, pub_key) when is_binary(pub_key) and byte_size(pub_key) == 64 do
+  @spec vote(%Tx{}, String.t()) :: %Tx{}
+  def vote(%Tx{} = tx, pub_key) when is_binary(pub_key) and byte_size(pub_key) == 64 do
     vote(tx, "+", pub_key)
   end
 
   @doc """
   Adds the delegate's public key to unvote.
   """
-  @spec unvote(%Dpos.Tx{}, String.t()) :: %Dpos.Tx{}
-  def unvote(%Dpos.Tx{} = tx, pub_key) when is_binary(pub_key) and byte_size(pub_key) == 64 do
+  @spec unvote(%Tx{}, String.t()) :: %Tx{}
+  def unvote(%Tx{} = tx, pub_key) when is_binary(pub_key) and byte_size(pub_key) == 64 do
     vote(tx, "-", pub_key)
-  end
-
-  defp get_child_bytes(%{asset: %{votes: votes}}) when is_list(votes),
-    do: <<Enum.join(votes)::bytes>>
-
-  defp get_child_bytes(_) do
-    [
-      "Please vote or unvote at least a public key\n",
-      "See Tx.Vote.vote/2\n",
-      "See Tx.Vote.unvote/2"
-    ]
-    |> Enum.join()
-    |> raise()
   end
 
   defp get_votes(%{asset: %{votes: votes}}) when is_list(votes), do: votes

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -19,7 +19,7 @@ defmodule Dpos.Utils do
   """
   @spec sign_message(String.t(), binary()) :: {:ok, binary()}
   def sign_message(msg, priv_key)
-      when is_binary(msg) and is_binary(priv_key) and byte_size(priv_key) == 64 do
+      when is_binary(msg) and is_binary(priv_key) and byte_size(priv_key) == 32 do
     Ed25519.sign(msg, priv_key)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Dpos.MixProject do
     [
       main: "readme",
       source_ref: "v#{@version}",
-      extras: ["README.md"]
+      extras: ["README.md", "LICENSE.txt"]
     ]
   end
 

--- a/test/tx/delegate_test.exs
+++ b/test/tx/delegate_test.exs
@@ -21,10 +21,10 @@ defmodule Tx.DelegateTest do
   def build_and_sign_tx() do
     wallet = Dpos.Wallet.generate(@delegate_secret)
 
-    %{fee: @tx.fee, timestamp: @tx.timestamp}
-    |> Tx.Delegate.build()
+    Tx.Delegate
+    |> Tx.build(%{fee: @tx.fee, timestamp: @tx.timestamp})
     |> Tx.Delegate.set_delegate("genesis_1")
-    |> Tx.Delegate.sign(wallet)
+    |> Tx.sign(wallet)
     |> Tx.normalize()
   end
 

--- a/test/tx/delegate_test.exs
+++ b/test/tx/delegate_test.exs
@@ -5,7 +5,7 @@ defmodule Tx.DelegateTest do
 
   @delegate_secret "robust swift grocery peasant forget share enable convince deputy road keep cheap"
 
-  @tx %Tx{
+  @tx %Tx.Normalized{
     type: 2,
     amount: 0,
     senderPublicKey: "9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f",

--- a/test/tx/delegate_test.exs
+++ b/test/tx/delegate_test.exs
@@ -1,9 +1,11 @@
-defmodule Dpos.Tx.DelegateTest do
+defmodule Tx.DelegateTest do
   use ExUnit.Case
+
+  alias Dpos.Tx
 
   @delegate_secret "robust swift grocery peasant forget share enable convince deputy road keep cheap"
 
-  @tx %Dpos.Tx{
+  @tx %Tx{
     type: 2,
     amount: 0,
     senderPublicKey: "9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f",
@@ -20,10 +22,10 @@ defmodule Dpos.Tx.DelegateTest do
     wallet = Dpos.Wallet.generate(@delegate_secret)
 
     %{fee: @tx.fee, timestamp: @tx.timestamp}
-    |> Dpos.Tx.Delegate.build()
-    |> Dpos.Tx.Delegate.set_delegate("genesis_1")
-    |> Dpos.Tx.Delegate.sign(wallet)
-    |> Dpos.Tx.Delegate.normalize()
+    |> Tx.Delegate.build()
+    |> Tx.Delegate.set_delegate("genesis_1")
+    |> Tx.Delegate.sign(wallet)
+    |> Tx.normalize()
   end
 
   describe "delegate transaction" do

--- a/test/tx/multi_sig_test.exs
+++ b/test/tx/multi_sig_test.exs
@@ -1,9 +1,11 @@
-defmodule Dpos.Tx.MultiSigTest do
+defmodule Tx.MultiSigTest do
   use ExUnit.Case
+
+  alias Dpos.Tx
 
   @secret "wagon stock borrow episode laundry kitten salute link globe zero feed marble"
 
-  @tx %Dpos.Tx{
+  @tx %Tx{
     type: 4,
     amount: 0,
     senderPublicKey: "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
@@ -30,20 +32,20 @@ defmodule Dpos.Tx.MultiSigTest do
     wallet = Dpos.Wallet.generate(@secret)
 
     %{fee: @tx.fee, timestamp: @tx.timestamp}
-    |> Dpos.Tx.MultiSig.build()
-    |> Dpos.Tx.MultiSig.set_lifetime(3600)
-    |> Dpos.Tx.MultiSig.set_min(2)
-    |> Dpos.Tx.MultiSig.add_public_key(
+    |> Tx.MultiSig.build()
+    |> Tx.MultiSig.set_lifetime(3600)
+    |> Tx.MultiSig.set_min(2)
+    |> Tx.MultiSig.add_public_key(
       "6267e1754d4b29cae9007fc0b3f0d435f981c90f70281ce053cb1c2243b848a2"
     )
-    |> Dpos.Tx.MultiSig.add_public_key(
+    |> Tx.MultiSig.add_public_key(
       "0bc54404ef644519592568687d2bc62593b912a57df319062bb7611b11009ebf"
     )
-    |> Dpos.Tx.MultiSig.add_public_key(
+    |> Tx.MultiSig.add_public_key(
       "b65aa5950acf1ade522bcf520f2b2491dcde2f312b4933f56443faff80ad8ebc"
     )
-    |> Dpos.Tx.MultiSig.sign(wallet)
-    |> Dpos.Tx.MultiSig.normalize()
+    |> Tx.MultiSig.sign(wallet)
+    |> Tx.normalize()
   end
 
   describe "multi sig transaction" do

--- a/test/tx/multi_sig_test.exs
+++ b/test/tx/multi_sig_test.exs
@@ -31,8 +31,8 @@ defmodule Tx.MultiSigTest do
   def build_and_sign_tx() do
     wallet = Dpos.Wallet.generate(@secret)
 
-    %{fee: @tx.fee, timestamp: @tx.timestamp}
-    |> Tx.MultiSig.build()
+    Tx.MultiSig
+    |> Tx.build(%{fee: @tx.fee, timestamp: @tx.timestamp})
     |> Tx.MultiSig.set_lifetime(3600)
     |> Tx.MultiSig.set_min(2)
     |> Tx.MultiSig.add_public_key(
@@ -44,7 +44,7 @@ defmodule Tx.MultiSigTest do
     |> Tx.MultiSig.add_public_key(
       "b65aa5950acf1ade522bcf520f2b2491dcde2f312b4933f56443faff80ad8ebc"
     )
-    |> Tx.MultiSig.sign(wallet)
+    |> Tx.sign(wallet)
     |> Tx.normalize()
   end
 

--- a/test/tx/multi_sig_test.exs
+++ b/test/tx/multi_sig_test.exs
@@ -5,7 +5,7 @@ defmodule Tx.MultiSigTest do
 
   @secret "wagon stock borrow episode laundry kitten salute link globe zero feed marble"
 
-  @tx %Tx{
+  @tx %Tx.Normalized{
     type: 4,
     amount: 0,
     senderPublicKey: "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",

--- a/test/tx/register_signature_test.exs
+++ b/test/tx/register_signature_test.exs
@@ -5,7 +5,7 @@ defmodule Tx.SecondSignatureTest do
 
   @delegate_secret "robust swift grocery peasant forget share enable convince deputy road keep cheap"
 
-  @tx %Tx{
+  @tx %Tx.Normalized{
     type: 1,
     amount: 0,
     fee: 2_500_000_000,

--- a/test/tx/register_signature_test.exs
+++ b/test/tx/register_signature_test.exs
@@ -1,9 +1,11 @@
-defmodule Dpos.Tx.SecondSignatureTest do
+defmodule Tx.SecondSignatureTest do
   use ExUnit.Case
+
+  alias Dpos.{Tx, Utils, Wallet}
 
   @delegate_secret "robust swift grocery peasant forget share enable convince deputy road keep cheap"
 
-  @tx %Dpos.Tx{
+  @tx %Tx{
     type: 1,
     amount: 0,
     fee: 2_500_000_000,
@@ -19,14 +21,14 @@ defmodule Dpos.Tx.SecondSignatureTest do
   }
 
   def build_and_sign_tx() do
-    wallet = Dpos.Wallet.generate(@delegate_secret)
-    {:ok, _, second_pub_key} = Dpos.Utils.seed_keypair("my secret")
+    wallet = Wallet.generate(@delegate_secret)
+    {:ok, _, second_pub_key} = Utils.seed_keypair("my secret")
 
     %{fee: @tx.fee, timestamp: @tx.timestamp}
-    |> Dpos.Tx.Signature.build()
-    |> Dpos.Tx.Signature.set_public_key(second_pub_key)
-    |> Dpos.Tx.Signature.sign(wallet)
-    |> Dpos.Tx.Signature.normalize()
+    |> Tx.Signature.build()
+    |> Tx.Signature.set_public_key(second_pub_key)
+    |> Tx.Signature.sign(wallet)
+    |> Tx.normalize()
   end
 
   describe "register signature transaction" do

--- a/test/tx/register_signature_test.exs
+++ b/test/tx/register_signature_test.exs
@@ -24,10 +24,10 @@ defmodule Tx.SecondSignatureTest do
     wallet = Wallet.generate(@delegate_secret)
     {:ok, _, second_pub_key} = Utils.seed_keypair("my secret")
 
-    %{fee: @tx.fee, timestamp: @tx.timestamp}
-    |> Tx.Signature.build()
+    Tx.Signature
+    |> Tx.build(%{fee: @tx.fee, timestamp: @tx.timestamp})
     |> Tx.Signature.set_public_key(second_pub_key)
-    |> Tx.Signature.sign(wallet)
+    |> Tx.sign(wallet)
     |> Tx.normalize()
   end
 

--- a/test/tx/send_second_sig_test.exs
+++ b/test/tx/send_second_sig_test.exs
@@ -24,16 +24,16 @@ defmodule Tx.SendSecondSigTest do
     wallet = Dpos.Wallet.generate(@secret)
     {:ok, second_priv_key, _} = Dpos.Utils.seed_keypair(@second_secret)
 
-    tx =
-      Tx.Send.build(%{
-        amount: @tx.amount,
-        timestamp: @tx.timestamp,
-        fee: @tx.fee,
-        recipient: @tx.recipientId
-      })
+    attrs = %{
+      amount: @tx.amount,
+      timestamp: @tx.timestamp,
+      fee: @tx.fee,
+      recipient: @tx.recipientId
+    }
 
-    tx
-    |> Tx.Send.sign(wallet, second_priv_key)
+    Tx.Send
+    |> Tx.build(attrs)
+    |> Tx.sign(wallet, second_priv_key)
     |> Tx.normalize()
   end
 

--- a/test/tx/send_second_sig_test.exs
+++ b/test/tx/send_second_sig_test.exs
@@ -6,7 +6,7 @@ defmodule Tx.SendSecondSigTest do
   @secret "jump bicycle member exist glare hip hero burger volume cover route rare"
   @second_secret "autumn foil east grape walnut mother hello favorite wink shaft fancy about"
 
-  @tx %Tx{
+  @tx %Tx.Normalized{
     type: 0,
     amount: 15,
     senderPublicKey: "904c294899819cce0283d8d351cb10febfa0e9f0acd90a820ec8eb90a7084c37",
@@ -29,7 +29,7 @@ defmodule Tx.SendSecondSigTest do
         amount: @tx.amount,
         timestamp: @tx.timestamp,
         fee: @tx.fee,
-        recipientId: @tx.recipientId
+        recipient: @tx.recipientId
       })
 
     tx

--- a/test/tx/send_second_sig_test.exs
+++ b/test/tx/send_second_sig_test.exs
@@ -1,10 +1,12 @@
-defmodule Dpos.Tx.SendSecondSigTest do
+defmodule Tx.SendSecondSigTest do
   use ExUnit.Case
+
+  alias Dpos.Tx
 
   @secret "jump bicycle member exist glare hip hero burger volume cover route rare"
   @second_secret "autumn foil east grape walnut mother hello favorite wink shaft fancy about"
 
-  @tx %Dpos.Tx{
+  @tx %Tx{
     type: 0,
     amount: 15,
     senderPublicKey: "904c294899819cce0283d8d351cb10febfa0e9f0acd90a820ec8eb90a7084c37",
@@ -23,7 +25,7 @@ defmodule Dpos.Tx.SendSecondSigTest do
     {:ok, second_priv_key, _} = Dpos.Utils.seed_keypair(@second_secret)
 
     tx =
-      Dpos.Tx.Send.build(%{
+      Tx.Send.build(%{
         amount: @tx.amount,
         timestamp: @tx.timestamp,
         fee: @tx.fee,
@@ -31,8 +33,8 @@ defmodule Dpos.Tx.SendSecondSigTest do
       })
 
     tx
-    |> Dpos.Tx.Send.sign(wallet, second_priv_key)
-    |> Dpos.Tx.Send.normalize()
+    |> Tx.Send.sign(wallet, second_priv_key)
+    |> Tx.normalize()
   end
 
   describe "send transaction" do

--- a/test/tx/send_test.exs
+++ b/test/tx/send_test.exs
@@ -1,9 +1,11 @@
-defmodule Dpos.Tx.SendTest do
+defmodule Tx.SendTest do
   use ExUnit.Case
+
+  alias Dpos.{Tx, Wallet}
 
   @secret "wagon stock borrow episode laundry kitten salute link globe zero feed marble"
 
-  @tx %Dpos.Tx{
+  @tx %Tx{
     type: 0,
     amount: 8840,
     senderPublicKey: "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
@@ -16,10 +18,10 @@ defmodule Dpos.Tx.SendTest do
   }
 
   def build_and_sign_tx() do
-    wallet = Dpos.Wallet.generate(@secret)
+    wallet = Wallet.generate(@secret)
 
     tx =
-      Dpos.Tx.Send.build(%{
+      Tx.Send.build(%{
         amount: @tx.amount,
         fee: @tx.fee,
         timestamp: @tx.timestamp,
@@ -28,8 +30,8 @@ defmodule Dpos.Tx.SendTest do
       })
 
     tx
-    |> Dpos.Tx.Send.sign(wallet)
-    |> Dpos.Tx.Send.normalize()
+    |> Tx.Send.sign(wallet)
+    |> Tx.normalize()
   end
 
   describe "send transaction" do

--- a/test/tx/send_test.exs
+++ b/test/tx/send_test.exs
@@ -21,7 +21,7 @@ defmodule Tx.SendTest do
     wallet = Wallet.generate(@secret)
 
     tx =
-      Tx.Send.build(%{
+      Tx.build(Tx.Send, %{
         amount: @tx.amount,
         fee: @tx.fee,
         timestamp: @tx.timestamp,
@@ -30,7 +30,7 @@ defmodule Tx.SendTest do
       })
 
     tx
-    |> Tx.Send.sign(wallet)
+    |> Tx.sign(wallet)
     |> Tx.normalize()
   end
 

--- a/test/tx/send_test.exs
+++ b/test/tx/send_test.exs
@@ -5,7 +5,7 @@ defmodule Tx.SendTest do
 
   @secret "wagon stock borrow episode laundry kitten salute link globe zero feed marble"
 
-  @tx %Tx{
+  @tx %Tx.Normalized{
     type: 0,
     amount: 8840,
     senderPublicKey: "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
@@ -25,8 +25,8 @@ defmodule Tx.SendTest do
         amount: @tx.amount,
         fee: @tx.fee,
         timestamp: @tx.timestamp,
-        senderPublicKey: wallet.pub_key,
-        recipientId: @tx.recipientId
+        public_key: wallet.pub_key,
+        recipient: @tx.recipientId
       })
 
     tx

--- a/test/tx/vote_test.exs
+++ b/test/tx/vote_test.exs
@@ -1,9 +1,11 @@
-defmodule Dpos.Tx.VoteTest do
+defmodule Tx.VoteTest do
   use ExUnit.Case
+
+  alias Dpos.Tx
 
   @secret "wagon stock borrow episode laundry kitten salute link globe zero feed marble"
 
-  @tx %Dpos.Tx{
+  @tx %Tx{
     type: 3,
     amount: 0,
     senderPublicKey: "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
@@ -24,16 +26,16 @@ defmodule Dpos.Tx.VoteTest do
     wallet = Dpos.Wallet.generate(@secret)
 
     tx =
-      Dpos.Tx.Vote.build(%{
+      Tx.Vote.build(%{
         fee: @tx.fee,
         timestamp: @tx.timestamp,
         recipientId: @tx.recipientId
       })
 
     tx
-    |> Dpos.Tx.Vote.vote("01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398db746")
-    |> Dpos.Tx.Vote.sign(wallet)
-    |> Dpos.Tx.Vote.normalize()
+    |> Tx.Vote.vote("01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398db746")
+    |> Tx.Vote.sign(wallet)
+    |> Tx.normalize()
   end
 
   describe "vote transaction" do

--- a/test/tx/vote_test.exs
+++ b/test/tx/vote_test.exs
@@ -1,11 +1,11 @@
 defmodule Tx.VoteTest do
   use ExUnit.Case
 
-  alias Dpos.Tx
+  alias Dpos.{Tx, Wallet}
 
   @secret "wagon stock borrow episode laundry kitten salute link globe zero feed marble"
 
-  @tx %Tx{
+  @tx %Tx.Normalized{
     type: 3,
     amount: 0,
     senderPublicKey: "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
@@ -23,13 +23,13 @@ defmodule Tx.VoteTest do
   }
 
   def build_and_sign_tx() do
-    wallet = Dpos.Wallet.generate(@secret)
+    wallet = Wallet.generate(@secret)
 
     tx =
       Tx.Vote.build(%{
         fee: @tx.fee,
         timestamp: @tx.timestamp,
-        recipientId: @tx.recipientId
+        recipient: @tx.recipientId
       })
 
     tx

--- a/test/tx/vote_test.exs
+++ b/test/tx/vote_test.exs
@@ -26,7 +26,7 @@ defmodule Tx.VoteTest do
     wallet = Wallet.generate(@secret)
 
     tx =
-      Tx.Vote.build(%{
+      Tx.build(Tx.Vote, %{
         fee: @tx.fee,
         timestamp: @tx.timestamp,
         recipient: @tx.recipientId
@@ -34,7 +34,7 @@ defmodule Tx.VoteTest do
 
     tx
     |> Tx.Vote.vote("01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398db746")
-    |> Tx.Vote.sign(wallet)
+    |> Tx.sign(wallet)
     |> Tx.normalize()
   end
 


### PR DESCRIPTION
Remove `Dpos.Tx` macro in favor of behaviors.
This allows developers to create their own custom exceptions easily by implementing `type_id/0` and `get_child_bytes/1`.